### PR TITLE
feat: 토큰 만료 관리 및 갱신 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.48.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.48.0
         version: 5.48.0(react@18.3.1)
@@ -985,6 +988,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.0':
     resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
     peerDependencies:
@@ -1091,6 +1107,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/rect@1.1.1':
@@ -3863,6 +3892,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.3
 
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -3943,6 +3992,15 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.3
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/rect@1.1.1': {}
 

--- a/src/2_pages/callback/CallbackPage.tsx
+++ b/src/2_pages/callback/CallbackPage.tsx
@@ -6,7 +6,7 @@ import { exchangeAuthCodeForAccessToken, getAccessibleResources, getMyself, pars
 import { useClientStore } from '@/5_entities/jira/jiraClientStore';
 
 function CallbackPage() {
-  const { setAccessToken, setCloudId, setCurrentUser } = useAuthStore();
+  const { setAccessToken, setRefreshToken, setExpiresAt, setCloudId, setCurrentUser } = useAuthStore();
   const { initClient } = useClientStore();
   const navigate = useNavigate();
 
@@ -20,10 +20,15 @@ function CallbackPage() {
 
     (async () => {
       try {
-        const { access_token: accessToken } = await exchangeAuthCodeForAccessToken(code);
+        const { access_token: accessToken, refresh_token: refreshToken, expires_in: expiresIn } =
+          await exchangeAuthCodeForAccessToken(code);
         const { id: cloudId } = (await getAccessibleResources(accessToken))[0];
 
+        const expiresAt = Date.now() + expiresIn * 1000;
+
         setAccessToken(accessToken);
+        setRefreshToken(refreshToken);
+        setExpiresAt(expiresAt);
         setCloudId(cloudId);
         initClient(accessToken, cloudId);
 
@@ -36,7 +41,7 @@ function CallbackPage() {
         navigate('/login', { replace: true });
       }
     })();
-  }, [navigate, setAccessToken, setCloudId, setCurrentUser, initClient]);
+  }, [navigate, setAccessToken, setRefreshToken, setExpiresAt, setCloudId, setCurrentUser, initClient]);
 
   return (
     <div className='flex flex-col items-center justify-center min-h-screen bg-gray-50'>

--- a/src/3_widgets/header/Header.tsx
+++ b/src/3_widgets/header/Header.tsx
@@ -1,3 +1,7 @@
+import { useState } from 'react';
+
+import { TokenCountdown } from '@/4_features/token-countdown';
+import { TokenExpiredModal } from '@/4_features/token-expired-modal';
 import { UserRegisterModal } from '@/4_features/user-register-modal';
 import { useAuth, useAuthStore } from '@/5_entities/auth';
 import { useIssueStore } from '@/5_entities/jira';
@@ -14,6 +18,7 @@ import {
 } from '@/6_shared/shadcn';
 
 function Header() {
+  const [showExpiredModal, setShowExpiredModal] = useState(false);
   const { logout } = useAuth();
   const { currentUser } = useAuthStore();
   const { isLoading, error } = useIssueStore();
@@ -26,10 +31,18 @@ function Header() {
     <div className='flex items-center gap-2 p-2 border-b'>
       <UserRegisterModal />
 
+      <TokenExpiredModal
+        open={showExpiredModal}
+        onClose={() => setShowExpiredModal(false)}
+        onLogout={logout}
+      />
+
       <div className='flex-1' />
 
       {isLoading() && <span className='text-sm text-blue-500'>로딩 중...</span>}
       {error && <span className='text-sm text-red-500'>{error}</span>}
+
+      <TokenCountdown onExpired={() => setShowExpiredModal(true)} />
 
       <DropdownMenu>
         <DropdownMenuTrigger className='flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-100 cursor-pointer'>

--- a/src/4_features/token-countdown/TokenCountdown.tsx
+++ b/src/4_features/token-countdown/TokenCountdown.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { useAuthStore } from '@/5_entities/auth';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/6_shared/shadcn';
+
+function formatTime(ms: number): string {
+  if (ms <= 0) return '00:00';
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+function TokenCountdown({ onExpired }: { onExpired: () => void }) {
+  const { expiresAt } = useAuthStore();
+  const [remainingTime, setRemainingTime] = useState<number>(0);
+  const intervalRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!expiresAt) return;
+
+    const updateRemainingTime = () => {
+      const remaining = expiresAt - Date.now();
+      setRemainingTime(remaining);
+
+      if (remaining <= 0) {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+          intervalRef.current = null;
+        }
+        onExpired();
+      }
+    };
+
+    updateRemainingTime();
+    intervalRef.current = window.setInterval(updateRemainingTime, 1000);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [expiresAt, onExpired]);
+
+  if (!expiresAt) return null;
+
+  const isWarning = remainingTime <= 5 * 60 * 1000; // 5분 이하
+  const isExpired = remainingTime <= 0;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={`text-sm font-mono cursor-help ${
+              isExpired ? 'text-red-600' : isWarning ? 'text-orange-500' : 'text-gray-500'
+            }`}
+          >
+            {formatTime(remainingTime)}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>세션 만료까지 남은 시간</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export default TokenCountdown;

--- a/src/4_features/token-countdown/TokenCountdown.tsx
+++ b/src/4_features/token-countdown/TokenCountdown.tsx
@@ -50,7 +50,7 @@ function TokenCountdown({ onExpired }: { onExpired: () => void }) {
   const isExpired = remainingTime <= 0;
 
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={50}>
       <Tooltip>
         <TooltipTrigger asChild>
           <span

--- a/src/4_features/token-countdown/index.ts
+++ b/src/4_features/token-countdown/index.ts
@@ -1,0 +1,1 @@
+export { default as TokenCountdown } from './TokenCountdown';

--- a/src/4_features/token-expired-modal/TokenExpiredModal.tsx
+++ b/src/4_features/token-expired-modal/TokenExpiredModal.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+
+import { refreshAccessToken, useAuthStore } from '@/5_entities/auth';
+import { useClientStore } from '@/5_entities/jira/jiraClientStore';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/6_shared/shadcn';
+
+type TokenExpiredModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onLogout: () => void;
+};
+
+function TokenExpiredModal({ open, onClose, onLogout }: TokenExpiredModalProps) {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { refreshToken, setAccessToken, setRefreshToken, setExpiresAt } = useAuthStore();
+  const { cloudId } = useAuthStore();
+  const { initClient } = useClientStore();
+
+  const handleRefresh = async () => {
+    if (!refreshToken) {
+      setError('갱신 토큰이 없습니다. 다시 로그인해주세요.');
+      return;
+    }
+
+    setIsRefreshing(true);
+    setError(null);
+
+    try {
+      const {
+        access_token: newAccessToken,
+        refresh_token: newRefreshToken,
+        expires_in: expiresIn,
+      } = await refreshAccessToken(refreshToken);
+
+      const expiresAt = Date.now() + expiresIn * 1000;
+
+      setAccessToken(newAccessToken);
+      setRefreshToken(newRefreshToken);
+      setExpiresAt(expiresAt);
+
+      if (cloudId) {
+        initClient(newAccessToken, cloudId);
+      }
+
+      onClose();
+    } catch (err) {
+      console.error('Token refresh failed:', err);
+      setError('토큰 갱신에 실패했습니다. 다시 로그인해주세요.');
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className='sm:max-w-[425px]'>
+        <DialogHeader>
+          <DialogTitle>토큰 만료</DialogTitle>
+          <DialogDescription>
+            인증 토큰이 만료되었습니다. 토큰을 갱신하시겠습니까?
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && <p className='text-sm text-red-500'>{error}</p>}
+
+        <DialogFooter>
+          <Button variant='outline' onClick={onLogout} disabled={isRefreshing}>
+            로그아웃
+          </Button>
+          <Button onClick={handleRefresh} disabled={isRefreshing}>
+            {isRefreshing ? '갱신 중...' : '토큰 갱신'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default TokenExpiredModal;

--- a/src/4_features/token-expired-modal/index.ts
+++ b/src/4_features/token-expired-modal/index.ts
@@ -1,0 +1,1 @@
+export { default as TokenExpiredModal } from './TokenExpiredModal';

--- a/src/5_entities/auth/authStore.ts
+++ b/src/5_entities/auth/authStore.ts
@@ -8,11 +8,16 @@ const TOKEN_KEY = 'jira-oauth-token';
 type AuthState = {
   accessToken?: string;
   setAccessToken: (accessToken: string) => void;
+  refreshToken?: string;
+  setRefreshToken: (refreshToken: string) => void;
+  expiresAt?: number;
+  setExpiresAt: (expiresAt: number) => void;
   cloudId?: string;
   setCloudId: (cloudid: string) => void;
   currentUser?: JiraCurrentUser;
   setCurrentUser: (user: JiraCurrentUser) => void;
   clearCurrentUser: () => void;
+  clearAuth: () => void;
 };
 
 export const useAuthStore = create<AuthState>()(
@@ -20,11 +25,23 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       accessToken: undefined,
       setAccessToken: (accessToken: string) => set({ accessToken }),
+      refreshToken: undefined,
+      setRefreshToken: (refreshToken: string) => set({ refreshToken }),
+      expiresAt: undefined,
+      setExpiresAt: (expiresAt: number) => set({ expiresAt }),
       cloudId: undefined,
       setCloudId: (cloudId: string) => set({ cloudId }),
       currentUser: undefined,
       setCurrentUser: (currentUser: JiraCurrentUser) => set({ currentUser }),
       clearCurrentUser: () => set({ currentUser: undefined }),
+      clearAuth: () =>
+        set({
+          accessToken: undefined,
+          refreshToken: undefined,
+          expiresAt: undefined,
+          cloudId: undefined,
+          currentUser: undefined,
+        }),
     }),
     { name: TOKEN_KEY },
   ),

--- a/src/5_entities/auth/index.ts
+++ b/src/5_entities/auth/index.ts
@@ -1,4 +1,4 @@
-export { getAuthorizationUrl, parseOauthCodeBySelf, exchangeAuthCodeForAccessToken, getMyself } from './oauth';
+export { getAuthorizationUrl, parseOauthCodeBySelf, exchangeAuthCodeForAccessToken, refreshAccessToken, getMyself } from './oauth';
 export type { JiraCurrentUser } from './oauth';
 export { useAuthStore } from './authStore';
 export { useAuth } from './useAuth';

--- a/src/5_entities/auth/oauth.ts
+++ b/src/5_entities/auth/oauth.ts
@@ -13,7 +13,7 @@ export function getAuthorizationUrl() {
     query: {
       audience: 'api.atlassian.com',
       client_id: CLIENT_ID,
-      scope: 'read:jira-work read:jira-user read:me',
+      scope: 'read:jira-work read:jira-user read:me offline_access',
       redirect_uri: REDIRECT_URI,
       state: new Date().getTime().toString(),
       response_type: 'code',
@@ -28,6 +28,7 @@ export function parseOauthCodeBySelf(): { code?: string; state?: string } {
 
 export async function exchangeAuthCodeForAccessToken(authCode: string): Promise<{
   access_token: string;
+  refresh_token: string;
   expires_in: number;
   scope: string;
   token_type: string;
@@ -40,6 +41,25 @@ export async function exchangeAuthCodeForAccessToken(authCode: string): Promise<
         client_secret: SECRET,
         code: authCode,
         redirect_uri: REDIRECT_URI,
+      },
+    })
+    .json();
+}
+
+export async function refreshAccessToken(refreshToken: string): Promise<{
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  scope: string;
+  token_type: string;
+}> {
+  return await ky
+    .post('https://auth.atlassian.com/oauth/token', {
+      json: {
+        grant_type: 'refresh_token',
+        client_id: CLIENT_ID,
+        client_secret: SECRET,
+        refresh_token: refreshToken,
       },
     })
     .json();

--- a/src/6_shared/shadcn/index.ts
+++ b/src/6_shared/shadcn/index.ts
@@ -23,3 +23,4 @@ export {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from './ui/dropdown-menu';
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip';

--- a/src/6_shared/shadcn/ui/tooltip.tsx
+++ b/src/6_shared/shadcn/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/6_shared/shadcn/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+      className
+    )}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }


### PR DESCRIPTION
## 배경 (문제 & 원인)

- 로그인 후 1시간이 지나면 access_token이 만료되어 401 에러 발생
- 새로고침해도 localStorage에 만료된 토큰이 남아있어 계속 실패
- 수동으로 로그아웃 → 재로그인 필요

## 작업 상세 (해결)

### 토큰 갱신 인프라 구축
- OAuth scope에 `offline_access` 추가하여 refresh_token 획득
- authStore에 `refreshToken`, `expiresAt` 필드 추가
- `refreshAccessToken()` 함수 구현

### 세션 만료 카운트다운 UI
- 헤더 우측에 남은 시간 표시 (mm:ss 형태)
- 5분 이하 시 주황색, 만료 시 빨간색으로 경고
- 툴팁으로 "세션 만료까지 남은 시간" 안내

### 토큰 갱신 모달
- 토큰 만료 시 갱신 여부 확인 모달 표시
- "토큰 갱신" 버튼 클릭 시 refresh_token으로 새 토큰 발급
- "로그아웃" 버튼으로 로그아웃 처리

## 테스트 방법 (기대 결과)

1. 로그인 후 헤더에 카운트다운 표시 확인
2. 시간 위에 마우스 올려 툴팁 확인
3. 만료 시 모달 표시 확인
4. 토큰 갱신 버튼 클릭 시 정상 갱신 확인

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)