### PR TITLE
feat: 사용자 목록 Export/Import 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.48.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.0
         version: 2.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.3)(react@18.3.1)
@@ -937,6 +940,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.8':
+    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3848,6 +3864,16 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-progress@1.1.8(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:

--- a/src/1_app/App.tsx
+++ b/src/1_app/App.tsx
@@ -7,6 +7,7 @@ import { LoginPage } from '@/2_pages/login';
 import MainPage from '@/2_pages/main';
 import { ProtectedRoute } from '@/4_features/protected-route';
 import { queryClient } from '@/6_shared/api/queryClient';
+import { TooltipProvider } from '@/6_shared/shadcn';
 
 import './react-calendar-custom-style.css';
 
@@ -15,16 +16,18 @@ const BASENAME = '/jira-timeline';
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter basename={BASENAME}>
-        <Routes>
-          <Route path='/login' element={<LoginPage />} />
-          <Route path='/callback' element={<CallbackPage />} />
-          <Route element={<ProtectedRoute />}>
-            <Route path='/' element={<MainPage />} />
-          </Route>
-          <Route path='*' element={<Navigate to='/login' replace />} />
-        </Routes>
-      </BrowserRouter>
+      <TooltipProvider>
+        <BrowserRouter basename={BASENAME}>
+          <Routes>
+            <Route path='/login' element={<LoginPage />} />
+            <Route path='/callback' element={<CallbackPage />} />
+            <Route element={<ProtectedRoute />}>
+              <Route path='/' element={<MainPage />} />
+            </Route>
+            <Route path='*' element={<Navigate to='/login' replace />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
     </QueryClientProvider>
   );
 }

--- a/src/2_pages/main/MainPage.tsx
+++ b/src/2_pages/main/MainPage.tsx
@@ -140,12 +140,24 @@ function MainPage() {
 
   // 사용자 목록 변경 시 데이터 초기화 및 재조회
   const isFirstMount = useRef(true);
+  const prevUserIdsRef = useRef<string>('');
+
   useEffect(() => {
     if (isFirstMount.current) {
       isFirstMount.current = false;
+      // 초기 사용자 ID 목록 저장
+      prevUserIdsRef.current = users.map((u) => u.id).join(',');
       return;
     }
     if (!client) return;
+
+    // 사용자 ID 목록이 실제로 변경되었는지 확인
+    const currentUserIds = users.map((u) => u.id).join(',');
+    if (prevUserIdsRef.current === currentUserIds) {
+      // ID 목록이 동일하면 재조회하지 않음
+      return;
+    }
+    prevUserIdsRef.current = currentUserIds;
 
     // 기존 데이터 초기화
     clear();

--- a/src/4_features/export-users/ExportUsersButton.tsx
+++ b/src/4_features/export-users/ExportUsersButton.tsx
@@ -1,13 +1,15 @@
 import { Upload } from 'lucide-react';
 
-import { useUserStore } from '@/5_entities/user';
+import type { JiraUser } from '@/5_entities/user';
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@/6_shared/shadcn';
 
 import { exportUsersToJson } from './util/exportUsersToJson';
 
-function ExportUsersButton() {
-  const { users } = useUserStore();
+type ExportUsersButtonProps = {
+  users: JiraUser[];
+};
 
+function ExportUsersButton({ users }: ExportUsersButtonProps) {
   const handleExport = () => {
     if (users.length === 0) {
       return;

--- a/src/4_features/export-users/ExportUsersButton.tsx
+++ b/src/4_features/export-users/ExportUsersButton.tsx
@@ -1,0 +1,32 @@
+import { Upload } from 'lucide-react';
+
+import { useUserStore } from '@/5_entities/user';
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@/6_shared/shadcn';
+
+import { exportUsersToJson } from './util/exportUsersToJson';
+
+function ExportUsersButton() {
+  const { users } = useUserStore();
+
+  const handleExport = () => {
+    if (users.length === 0) {
+      return;
+    }
+    exportUsersToJson(users);
+  };
+
+  return (
+    <Tooltip delayDuration={50}>
+      <TooltipTrigger asChild>
+        <Button variant='outline' size='sm' onClick={handleExport} disabled={users.length === 0}>
+          <Upload className='h-4 w-4' />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>사용자 목록 내보내기</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export default ExportUsersButton;

--- a/src/4_features/export-users/index.ts
+++ b/src/4_features/export-users/index.ts
@@ -1,0 +1,1 @@
+export { default as ExportUsersButton } from './ExportUsersButton';

--- a/src/4_features/export-users/test/exportUsersToJson.test.ts
+++ b/src/4_features/export-users/test/exportUsersToJson.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createExportData, createFilename } from '../util/exportUsersToJson';
+
+describe('createExportData', () => {
+  it('should convert JiraUser array to ExportData format', () => {
+    const users = [
+      { id: 'abc123', displayName: '홍길동', isVerified: true },
+      { id: 'def456', displayName: '김철수', isVerified: true },
+    ];
+
+    const result = createExportData(users);
+
+    expect(result.version).toBe(1);
+    expect(result.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(result.users).toEqual([
+      { id: 'abc123', displayName: '홍길동' },
+      { id: 'def456', displayName: '김철수' },
+    ]);
+  });
+
+  it('should handle users without displayName', () => {
+    const users = [
+      { id: 'abc123', displayName: undefined, isVerified: false },
+    ];
+
+    const result = createExportData(users);
+
+    expect(result.users).toEqual([
+      { id: 'abc123', displayName: undefined },
+    ]);
+  });
+
+  it('should handle empty users array', () => {
+    const result = createExportData([]);
+
+    expect(result.version).toBe(1);
+    expect(result.users).toEqual([]);
+  });
+
+  it('should exclude isVerified field from export', () => {
+    const users = [
+      { id: 'abc123', displayName: '홍길동', isVerified: true },
+    ];
+
+    const result = createExportData(users);
+
+    expect(result.users[0]).not.toHaveProperty('isVerified');
+  });
+});
+
+describe('createFilename', () => {
+  it('should return filename with current date in YYYY-MM-DD format', () => {
+    const mockDate = new Date('2024-01-29T12:00:00.000Z');
+    vi.setSystemTime(mockDate);
+
+    const result = createFilename();
+
+    expect(result).toBe('jira-users-2024-01-29.json');
+
+    vi.useRealTimers();
+  });
+
+  it('should pad month and day with leading zeros', () => {
+    const mockDate = new Date('2024-03-05T12:00:00.000Z');
+    vi.setSystemTime(mockDate);
+
+    const result = createFilename();
+
+    expect(result).toBe('jira-users-2024-03-05.json');
+
+    vi.useRealTimers();
+  });
+});

--- a/src/4_features/export-users/util/exportUsersToJson.ts
+++ b/src/4_features/export-users/util/exportUsersToJson.ts
@@ -1,0 +1,51 @@
+import { type JiraUser } from '@/5_entities/user';
+
+type ExportUser = {
+  id: string;
+  displayName?: string;
+};
+
+type ExportData = {
+  version: 1;
+  exportedAt: string;
+  users: ExportUser[];
+};
+
+export function createExportData(users: JiraUser[]): ExportData {
+  return {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    users: users.map((user) => ({
+      id: user.id,
+      displayName: user.displayName,
+    })),
+  };
+}
+
+export function createFilename(): string {
+  const date = new Date();
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `jira-users-${yyyy}-${mm}-${dd}.json`;
+}
+
+export function downloadJson(data: ExportData, filename: string): void {
+  const jsonString = JSON.stringify(data, null, 2);
+  const blob = new Blob([jsonString], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function exportUsersToJson(users: JiraUser[]): void {
+  const data = createExportData(users);
+  const filename = createFilename();
+  downloadJson(data, filename);
+}

--- a/src/4_features/import-users/ImportProgressDialog.tsx
+++ b/src/4_features/import-users/ImportProgressDialog.tsx
@@ -1,0 +1,109 @@
+import { CheckCircle2, XCircle } from 'lucide-react';
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Progress,
+} from '@/6_shared/shadcn';
+
+import type { ValidationProgress, ValidationResult } from './util/validateUsers';
+
+type ImportProgressDialogProps = {
+  open: boolean;
+  progress: ValidationProgress | null;
+  result: ValidationResult | null;
+  onClose: () => void;
+  onCancel: () => void;
+};
+
+function ImportProgressDialog({
+  open,
+  progress,
+  result,
+  onClose,
+  onCancel,
+}: ImportProgressDialogProps) {
+  const isCompleted = result !== null;
+  const progressPercent = progress ? (progress.current / progress.total) * 100 : 0;
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isCompleted ? '가져오기 완료' : '사용자 검증 중'}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-4">
+          {!isCompleted && progress && (
+            <>
+              <div className="text-sm text-muted-foreground">
+                검증 중... ({progress.current}/{progress.total})
+              </div>
+              <Progress value={progressPercent} className="h-2" />
+              <div className="text-sm text-muted-foreground truncate" title={progress.currentUserId}>
+                현재: {progress.currentUserId}
+              </div>
+              <div className="flex gap-4 text-sm">
+                <span className="flex items-center gap-1 text-green-600">
+                  <CheckCircle2 className="h-4 w-4" />
+                  성공: {progress.successCount}명
+                </span>
+                <span className="flex items-center gap-1 text-red-500">
+                  <XCircle className="h-4 w-4" />
+                  실패: {progress.failedCount}명
+                </span>
+              </div>
+            </>
+          )}
+
+          {isCompleted && result && (
+            <>
+              <div className="text-sm">
+                총 {result.validUsers.length + result.failedIds.length}명 중{' '}
+                <span className="font-medium">{result.validUsers.length}명</span> 등록 완료
+              </div>
+              <div className="flex gap-4 text-sm">
+                <span className="flex items-center gap-1 text-green-600">
+                  <CheckCircle2 className="h-4 w-4" />
+                  성공: {result.validUsers.length}명
+                </span>
+                <span className="flex items-center gap-1 text-red-500">
+                  <XCircle className="h-4 w-4" />
+                  실패: {result.failedIds.length}명
+                </span>
+              </div>
+              {result.failedIds.length > 0 && (
+                <div className="text-sm">
+                  <div className="text-muted-foreground mb-1">실패한 ID:</div>
+                  <ul className="list-disc list-inside max-h-32 overflow-y-auto text-red-500">
+                    {result.failedIds.map((id) => (
+                      <li key={id} className="truncate" title={id}>
+                        {id}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          {!isCompleted ? (
+            <Button variant="secondary" onClick={onCancel}>
+              취소
+            </Button>
+          ) : (
+            <Button onClick={onClose}>확인</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default ImportProgressDialog;

--- a/src/4_features/import-users/ImportUsersButton.tsx
+++ b/src/4_features/import-users/ImportUsersButton.tsx
@@ -1,0 +1,209 @@
+import { Download } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+
+import { useClientStore } from '@/5_entities/jira';
+import { type JiraUser, useUserStore } from '@/5_entities/user';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Label,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/6_shared/shadcn';
+
+import ImportProgressDialog from './ImportProgressDialog';
+import { parseUsersJson } from './util/parseUsersJson';
+import { type ValidationProgress, type ValidationResult, validateUsers } from './util/validateUsers';
+
+type ImportMode = 'merge' | 'replace';
+
+type ImportUsersButtonProps = {
+  onImportComplete?: (users: JiraUser[]) => void;
+};
+
+function ImportUsersButton({ onImportComplete }: ImportUsersButtonProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const { client } = useClientStore();
+  const { users, setUsers } = useUserStore();
+
+  const [parsedUserIds, setParsedUserIds] = useState<string[]>([]);
+  const [showModeDialog, setShowModeDialog] = useState(false);
+  const [importMode, setImportMode] = useState<ImportMode>('merge');
+  const [isImporting, setIsImporting] = useState(false);
+  const [progress, setProgress] = useState<ValidationProgress | null>(null);
+  const [result, setResult] = useState<ValidationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFileSelect = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    event.target.value = '';
+
+    try {
+      const text = await file.text();
+      const parseResult = parseUsersJson(text);
+
+      if (!parseResult.success) {
+        setError(parseResult.error);
+        return;
+      }
+
+      setParsedUserIds(parseResult.userIds);
+      setShowModeDialog(true);
+    } catch {
+      setError('파일을 읽을 수 없습니다');
+    }
+  }, []);
+
+  const handleStartImport = useCallback(async () => {
+    if (!client) {
+      setError('Jira 클라이언트가 초기화되지 않았습니다');
+      return;
+    }
+
+    setShowModeDialog(false);
+    setIsImporting(true);
+    setProgress(null);
+    setResult(null);
+
+    abortControllerRef.current = new AbortController();
+
+    const existingUsers = importMode === 'merge' ? users : [];
+
+    const validationResult = await validateUsers(
+      client,
+      parsedUserIds,
+      existingUsers,
+      setProgress,
+      abortControllerRef.current.signal,
+    );
+
+    setResult(validationResult);
+
+    if (!abortControllerRef.current.signal.aborted) {
+      let newUsers: JiraUser[];
+
+      if (importMode === 'merge') {
+        const existingIds = new Set(users.map((u) => u.id));
+        const newValidUsers = validationResult.validUsers.filter((u) => !existingIds.has(u.id));
+        newUsers = [...users, ...newValidUsers];
+      } else {
+        newUsers = validationResult.validUsers;
+      }
+
+      setUsers(newUsers);
+      onImportComplete?.(newUsers);
+    }
+  }, [client, parsedUserIds, users, importMode, setUsers, onImportComplete]);
+
+  const handleCancel = useCallback(() => {
+    abortControllerRef.current?.abort();
+  }, []);
+
+  const handleCloseProgress = useCallback(() => {
+    setIsImporting(false);
+    setProgress(null);
+    setResult(null);
+  }, []);
+
+  const handleCloseError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return (
+    <>
+      <input type='file' accept='.json' hidden ref={fileInputRef} onChange={handleFileSelect} />
+      <Tooltip delayDuration={50}>
+        <TooltipTrigger asChild>
+          <Button variant='outline' size='sm' onClick={() => fileInputRef.current?.click()}>
+            <Download className='h-4 w-4' />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>사용자 목록 가져오기</p>
+        </TooltipContent>
+      </Tooltip>
+
+      <Dialog open={showModeDialog} onOpenChange={setShowModeDialog}>
+        <DialogContent className='max-w-sm'>
+          <DialogHeader>
+            <DialogTitle>가져오기 방식 선택</DialogTitle>
+          </DialogHeader>
+
+          <div className='flex flex-col gap-3 py-4'>
+            <p className='text-sm text-muted-foreground'>{parsedUserIds.length}명의 사용자를 가져옵니다.</p>
+
+            <div className='flex flex-col gap-2'>
+              <Label className='flex items-start gap-2 cursor-pointer'>
+                <input
+                  type='radio'
+                  name='importMode'
+                  value='merge'
+                  checked={importMode === 'merge'}
+                  onChange={() => setImportMode('merge')}
+                  className='mt-1'
+                />
+                <div>
+                  <div className='font-medium'>병합</div>
+                  <div className='text-sm text-muted-foreground'>기존 사용자 유지, 새 사용자만 추가</div>
+                </div>
+              </Label>
+
+              <Label className='flex items-start gap-2 cursor-pointer'>
+                <input
+                  type='radio'
+                  name='importMode'
+                  value='replace'
+                  checked={importMode === 'replace'}
+                  onChange={() => setImportMode('replace')}
+                  className='mt-1'
+                />
+                <div>
+                  <div className='font-medium'>대체</div>
+                  <div className='text-sm text-muted-foreground'>기존 사용자 삭제 후 교체</div>
+                </div>
+              </Label>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant='secondary' onClick={() => setShowModeDialog(false)}>
+              취소
+            </Button>
+            <Button onClick={handleStartImport}>확인</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ImportProgressDialog
+        open={isImporting}
+        progress={progress}
+        result={result}
+        onClose={handleCloseProgress}
+        onCancel={handleCancel}
+      />
+
+      <Dialog open={error !== null} onOpenChange={(open) => !open && handleCloseError()}>
+        <DialogContent className='max-w-sm'>
+          <DialogHeader>
+            <DialogTitle>오류</DialogTitle>
+          </DialogHeader>
+          <div className='py-4 text-sm text-red-500'>{error}</div>
+          <DialogFooter>
+            <Button onClick={handleCloseError}>확인</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default ImportUsersButton;

--- a/src/4_features/import-users/ImportUsersButton.tsx
+++ b/src/4_features/import-users/ImportUsersButton.tsx
@@ -86,22 +86,25 @@ function ImportUsersButton({ onImportComplete }: ImportUsersButtonProps) {
       abortControllerRef.current.signal,
     );
 
+    if (abortControllerRef.current.signal.aborted) {
+      setIsImporting(false);
+      return;
+    }
+
     setResult(validationResult);
 
-    if (!abortControllerRef.current.signal.aborted) {
-      let newUsers: JiraUser[];
+    let newUsers: JiraUser[];
 
-      if (importMode === 'merge') {
-        const existingIds = new Set(users.map((u) => u.id));
-        const newValidUsers = validationResult.validUsers.filter((u) => !existingIds.has(u.id));
-        newUsers = [...users, ...newValidUsers];
-      } else {
-        newUsers = validationResult.validUsers;
-      }
-
-      setUsers(newUsers);
-      onImportComplete?.(newUsers);
+    if (importMode === 'merge') {
+      const existingIds = new Set(users.map((u) => u.id));
+      const newValidUsers = validationResult.validUsers.filter((u) => !existingIds.has(u.id));
+      newUsers = [...users, ...newValidUsers];
+    } else {
+      newUsers = validationResult.validUsers;
     }
+
+    setUsers(newUsers);
+    onImportComplete?.(newUsers);
   }, [client, parsedUserIds, users, importMode, setUsers, onImportComplete]);
 
   const handleCancel = useCallback(() => {
@@ -109,9 +112,8 @@ function ImportUsersButton({ onImportComplete }: ImportUsersButtonProps) {
   }, []);
 
   const handleCloseProgress = useCallback(() => {
+    abortControllerRef.current?.abort();
     setIsImporting(false);
-    setProgress(null);
-    setResult(null);
   }, []);
 
   const handleCloseError = useCallback(() => {

--- a/src/4_features/import-users/ImportUsersButton.tsx
+++ b/src/4_features/import-users/ImportUsersButton.tsx
@@ -2,7 +2,7 @@ import { Download } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 
 import { useClientStore } from '@/5_entities/jira';
-import { type JiraUser, useUserStore } from '@/5_entities/user';
+import type { JiraUser } from '@/5_entities/user';
 import {
   Button,
   Dialog,
@@ -23,15 +23,15 @@ import { type ValidationProgress, type ValidationResult, validateUsers } from '.
 type ImportMode = 'merge' | 'replace';
 
 type ImportUsersButtonProps = {
+  currentUsers: JiraUser[];
   onImportComplete?: (users: JiraUser[]) => void;
 };
 
-function ImportUsersButton({ onImportComplete }: ImportUsersButtonProps) {
+function ImportUsersButton({ currentUsers, onImportComplete }: ImportUsersButtonProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const { client } = useClientStore();
-  const { users, setUsers } = useUserStore();
 
   const [parsedUserIds, setParsedUserIds] = useState<string[]>([]);
   const [showModeDialog, setShowModeDialog] = useState(false);
@@ -76,7 +76,7 @@ function ImportUsersButton({ onImportComplete }: ImportUsersButtonProps) {
 
     abortControllerRef.current = new AbortController();
 
-    const existingUsers = importMode === 'merge' ? users : [];
+    const existingUsers = importMode === 'merge' ? currentUsers : [];
 
     const validationResult = await validateUsers(
       client,
@@ -96,16 +96,15 @@ function ImportUsersButton({ onImportComplete }: ImportUsersButtonProps) {
     let newUsers: JiraUser[];
 
     if (importMode === 'merge') {
-      const existingIds = new Set(users.map((u) => u.id));
+      const existingIds = new Set(currentUsers.map((u) => u.id));
       const newValidUsers = validationResult.validUsers.filter((u) => !existingIds.has(u.id));
-      newUsers = [...users, ...newValidUsers];
+      newUsers = [...currentUsers, ...newValidUsers];
     } else {
       newUsers = validationResult.validUsers;
     }
 
-    setUsers(newUsers);
     onImportComplete?.(newUsers);
-  }, [client, parsedUserIds, users, importMode, setUsers, onImportComplete]);
+  }, [client, parsedUserIds, currentUsers, importMode, onImportComplete]);
 
   const handleCancel = useCallback(() => {
     abortControllerRef.current?.abort();

--- a/src/4_features/import-users/index.ts
+++ b/src/4_features/import-users/index.ts
@@ -1,0 +1,1 @@
+export { default as ImportUsersButton } from './ImportUsersButton';

--- a/src/4_features/import-users/test/parseUsersJson.test.ts
+++ b/src/4_features/import-users/test/parseUsersJson.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseUsersJson } from '../util/parseUsersJson';
+
+describe('parseUsersJson', () => {
+  describe('Export 형식 파싱', () => {
+    it('should parse full export format with version', () => {
+      const json = JSON.stringify({
+        version: 1,
+        exportedAt: '2024-01-29T12:00:00.000Z',
+        users: [
+          { id: 'abc123', displayName: '홍길동' },
+          { id: 'def456', displayName: '김철수' },
+        ],
+      });
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.userIds).toEqual(['abc123', 'def456']);
+      }
+    });
+
+    it('should parse simple object format with users array', () => {
+      const json = JSON.stringify({
+        users: [{ id: 'abc123' }, { id: 'def456' }],
+      });
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.userIds).toEqual(['abc123', 'def456']);
+      }
+    });
+
+    it('should parse users array with string IDs', () => {
+      const json = JSON.stringify({
+        users: ['abc123', 'def456'],
+      });
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.userIds).toEqual(['abc123', 'def456']);
+      }
+    });
+  });
+
+  describe('배열 형식 파싱', () => {
+    it('should parse plain string array', () => {
+      const json = JSON.stringify(['abc123', 'def456', 'ghi789']);
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.userIds).toEqual(['abc123', 'def456', 'ghi789']);
+      }
+    });
+  });
+
+  describe('중복 및 공백 처리', () => {
+    it('should remove duplicate IDs', () => {
+      const json = JSON.stringify(['abc123', 'def456', 'abc123', 'def456']);
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.userIds).toEqual(['abc123', 'def456']);
+      }
+    });
+
+    it('should trim whitespace from IDs', () => {
+      const json = JSON.stringify(['  abc123  ', '  def456  ']);
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.userIds).toEqual(['abc123', 'def456']);
+      }
+    });
+
+    it('should filter out empty strings', () => {
+      const json = JSON.stringify(['abc123', '', '  ', 'def456']);
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.userIds).toEqual(['abc123', 'def456']);
+      }
+    });
+  });
+
+  describe('에러 케이스', () => {
+    it('should return error for invalid JSON', () => {
+      const result = parseUsersJson('not a json');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('올바른 JSON 형식이 아닙니다');
+      }
+    });
+
+    it('should return error for unsupported format', () => {
+      const json = JSON.stringify({ name: 'test' });
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('지원하지 않는 파일 형식입니다');
+      }
+    });
+
+    it('should return error for empty users array', () => {
+      const json = JSON.stringify({ users: [] });
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('유효한 사용자 ID가 없습니다');
+      }
+    });
+
+    it('should return error for array of empty strings only', () => {
+      const json = JSON.stringify(['', '  ', '   ']);
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('유효한 사용자 ID가 없습니다');
+      }
+    });
+
+    it('should return error for number instead of string', () => {
+      const json = JSON.stringify(12345);
+
+      const result = parseUsersJson(json);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('지원하지 않는 파일 형식입니다');
+      }
+    });
+  });
+});

--- a/src/4_features/import-users/test/validateUsers.test.ts
+++ b/src/4_features/import-users/test/validateUsers.test.ts
@@ -1,0 +1,125 @@
+import { type Version3Client } from 'jira.js';
+import { describe, expect, it, vi } from 'vitest';
+
+import { validateUsers } from '../util/validateUsers';
+
+vi.mock('@/5_entities/jira', () => ({
+  getJiraUser: vi.fn(),
+}));
+
+import { getJiraUser } from '@/5_entities/jira';
+
+const mockGetJiraUser = vi.mocked(getJiraUser);
+
+describe('validateUsers', () => {
+  const mockClient = {} as Version3Client;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should validate users and return valid users', async () => {
+    mockGetJiraUser
+      .mockResolvedValueOnce({ accountId: 'abc123', displayName: '홍길동' })
+      .mockResolvedValueOnce({ accountId: 'def456', displayName: '김철수' });
+
+    const result = await validateUsers(mockClient, ['abc123', 'def456'], []);
+
+    expect(result.validUsers).toHaveLength(2);
+    expect(result.validUsers[0]).toEqual({
+      id: 'abc123',
+      displayName: '홍길동',
+      isVerified: true,
+    });
+    expect(result.failedIds).toHaveLength(0);
+  });
+
+  it('should collect failed IDs', async () => {
+    mockGetJiraUser
+      .mockResolvedValueOnce({ accountId: 'abc123', displayName: '홍길동' })
+      .mockResolvedValueOnce(null);
+
+    const result = await validateUsers(mockClient, ['abc123', 'invalid-id'], []);
+
+    expect(result.validUsers).toHaveLength(1);
+    expect(result.failedIds).toEqual(['invalid-id']);
+  });
+
+  it('should use cached users instead of API call', async () => {
+    const existingUsers = [
+      { id: 'abc123', displayName: '홍길동', isVerified: true },
+    ];
+
+    mockGetJiraUser.mockResolvedValueOnce({ accountId: 'def456', displayName: '김철수' });
+
+    const result = await validateUsers(mockClient, ['abc123', 'def456'], existingUsers);
+
+    expect(mockGetJiraUser).toHaveBeenCalledTimes(1);
+    expect(mockGetJiraUser).toHaveBeenCalledWith(mockClient, 'def456');
+    expect(result.validUsers).toHaveLength(2);
+  });
+
+  it('should not use unverified users from cache', async () => {
+    const existingUsers = [
+      { id: 'abc123', displayName: undefined, isVerified: false },
+    ];
+
+    mockGetJiraUser.mockResolvedValueOnce({ accountId: 'abc123', displayName: '홍길동' });
+
+    const result = await validateUsers(mockClient, ['abc123'], existingUsers);
+
+    expect(mockGetJiraUser).toHaveBeenCalledTimes(1);
+    expect(result.validUsers[0].displayName).toBe('홍길동');
+  });
+
+  it('should call onProgress callback', async () => {
+    mockGetJiraUser
+      .mockResolvedValueOnce({ accountId: 'abc123', displayName: '홍길동' })
+      .mockResolvedValueOnce({ accountId: 'def456', displayName: '김철수' });
+
+    const onProgress = vi.fn();
+
+    await validateUsers(mockClient, ['abc123', 'def456'], [], onProgress);
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenNthCalledWith(1, {
+      current: 1,
+      total: 2,
+      successCount: 0,
+      failedCount: 0,
+      currentUserId: 'abc123',
+    });
+    expect(onProgress).toHaveBeenNthCalledWith(2, {
+      current: 2,
+      total: 2,
+      successCount: 1,
+      failedCount: 0,
+      currentUserId: 'def456',
+    });
+  });
+
+  it('should stop when aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    mockGetJiraUser.mockResolvedValue({ accountId: 'abc123', displayName: '홍길동' });
+
+    const result = await validateUsers(
+      mockClient,
+      ['abc123', 'def456'],
+      [],
+      undefined,
+      controller.signal,
+    );
+
+    expect(mockGetJiraUser).not.toHaveBeenCalled();
+    expect(result.validUsers).toHaveLength(0);
+  });
+
+  it('should handle empty userIds array', async () => {
+    const result = await validateUsers(mockClient, [], []);
+
+    expect(result.validUsers).toHaveLength(0);
+    expect(result.failedIds).toHaveLength(0);
+  });
+});

--- a/src/4_features/import-users/util/parseUsersJson.ts
+++ b/src/4_features/import-users/util/parseUsersJson.ts
@@ -1,0 +1,67 @@
+type ParseSuccess = {
+  success: true;
+  userIds: string[];
+};
+
+type ParseError = {
+  success: false;
+  error: string;
+};
+
+export type ParseResult = ParseSuccess | ParseError;
+
+type ExportFormat = {
+  version?: number;
+  users: Array<{ id: string; displayName?: string } | string>;
+};
+
+function isExportFormat(data: unknown): data is ExportFormat {
+  if (typeof data !== 'object' || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return Array.isArray(obj.users);
+}
+
+function isStringArray(data: unknown): data is string[] {
+  return Array.isArray(data) && data.every((item) => typeof item === 'string');
+}
+
+function extractUserIds(users: Array<{ id: string; displayName?: string } | string>): string[] {
+  return users.map((user) => {
+    if (typeof user === 'string') {
+      return user;
+    }
+    return user.id;
+  });
+}
+
+export function parseUsersJson(jsonString: string): ParseResult {
+  let data: unknown;
+
+  try {
+    data = JSON.parse(jsonString);
+  } catch {
+    return { success: false, error: '올바른 JSON 형식이 아닙니다' };
+  }
+
+  let userIds: string[];
+
+  if (isExportFormat(data)) {
+    userIds = extractUserIds(data.users);
+  } else if (isStringArray(data)) {
+    userIds = data;
+  } else {
+    return { success: false, error: '지원하지 않는 파일 형식입니다' };
+  }
+
+  const validIds = userIds
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+
+  const uniqueIds = [...new Set(validIds)];
+
+  if (uniqueIds.length === 0) {
+    return { success: false, error: '유효한 사용자 ID가 없습니다' };
+  }
+
+  return { success: true, userIds: uniqueIds };
+}

--- a/src/4_features/import-users/util/validateUsers.ts
+++ b/src/4_features/import-users/util/validateUsers.ts
@@ -1,0 +1,71 @@
+import { type Version3Client } from 'jira.js';
+
+import { getJiraUser } from '@/5_entities/jira';
+import { type JiraUser } from '@/5_entities/user';
+
+export type ValidationProgress = {
+  current: number;
+  total: number;
+  successCount: number;
+  failedCount: number;
+  currentUserId: string;
+};
+
+export type ValidationResult = {
+  validUsers: JiraUser[];
+  failedIds: string[];
+};
+
+export async function validateUsers(
+  client: Version3Client,
+  userIds: string[],
+  existingUsers: JiraUser[],
+  onProgress?: (progress: ValidationProgress) => void,
+  signal?: AbortSignal,
+): Promise<ValidationResult> {
+  const validUsers: JiraUser[] = [];
+  const failedIds: string[] = [];
+
+  const existingVerifiedMap = new Map<string, JiraUser>();
+  existingUsers.forEach((user) => {
+    if (user.isVerified) {
+      existingVerifiedMap.set(user.id, user);
+    }
+  });
+
+  for (let i = 0; i < userIds.length; i++) {
+    if (signal?.aborted) {
+      break;
+    }
+
+    const userId = userIds[i];
+
+    onProgress?.({
+      current: i + 1,
+      total: userIds.length,
+      successCount: validUsers.length,
+      failedCount: failedIds.length,
+      currentUserId: userId,
+    });
+
+    const existingUser = existingVerifiedMap.get(userId);
+    if (existingUser) {
+      validUsers.push(existingUser);
+      continue;
+    }
+
+    const userInfo = await getJiraUser(client, userId);
+
+    if (userInfo) {
+      validUsers.push({
+        id: userInfo.accountId,
+        displayName: userInfo.displayName,
+        isVerified: true,
+      });
+    } else {
+      failedIds.push(userId);
+    }
+  }
+
+  return { validUsers, failedIds };
+}

--- a/src/4_features/user-register-modal/UserRegisterModal.tsx
+++ b/src/4_features/user-register-modal/UserRegisterModal.tsx
@@ -1,6 +1,8 @@
 import { Loader2, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { ExportUsersButton } from '@/4_features/export-users';
+import { ImportUsersButton } from '@/4_features/import-users';
 import { getJiraUser, useClientStore } from '@/5_entities/jira';
 import { type JiraUser, useUserStore } from '@/5_entities/user';
 import {
@@ -58,9 +60,7 @@ function UserRegisterModal() {
     async (index: number, accountId: string) => {
       if (!client || !accountId.trim()) return;
 
-      setRows((prev) =>
-        prev.map((row, i) => (i === index ? { ...row, isLoading: true, hasError: false } : row)),
-      );
+      setRows((prev) => prev.map((row, i) => (i === index ? { ...row, isLoading: true, hasError: false } : row)));
 
       const userInfo = await getJiraUser(client, accountId.trim());
 
@@ -84,9 +84,7 @@ function UserRegisterModal() {
   const handleIdChange = (index: number, value: string) => {
     setRows((prev) =>
       prev.map((row, i) =>
-        i === index
-          ? { ...row, id: value, displayName: undefined, isVerified: false, hasError: false }
-          : row,
+        i === index ? { ...row, id: value, displayName: undefined, isVerified: false, hasError: false } : row,
       ),
     );
 
@@ -107,9 +105,7 @@ function UserRegisterModal() {
     if (cachedUser) {
       setRows((prev) =>
         prev.map((row, i) =>
-          i === index
-            ? { ...row, displayName: cachedUser.displayName, isVerified: true, hasError: false }
-            : row,
+          i === index ? { ...row, displayName: cachedUser.displayName, isVerified: true, hasError: false } : row,
         ),
       );
       return;
@@ -172,6 +168,20 @@ function UserRegisterModal() {
     setOpen(false);
   };
 
+  const handleImportComplete = useCallback((importedUsers: JiraUser[]) => {
+    const newRows: UserRow[] =
+      importedUsers.length > 0
+        ? importedUsers.map((u) => ({
+            id: u.id,
+            displayName: u.displayName,
+            isVerified: u.isVerified,
+            isLoading: false,
+            hasError: !u.isVerified,
+          }))
+        : [{ id: '', displayName: undefined, isVerified: false, isLoading: false, hasError: false }];
+    setRows(newRows);
+  }, []);
+
   // 컴포넌트 언마운트 시 타이머 정리
   useEffect(() => {
     return () => {
@@ -182,66 +192,65 @@ function UserRegisterModal() {
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button variant="outline">사용자 관리</Button>
+        <Button variant='outline'>사용자 관리</Button>
       </DialogTrigger>
-      <DialogContent className="max-w-xl max-h-[80vh] flex flex-col">
-        <DialogHeader>
+      <DialogContent className='max-w-xl max-h-[80vh] flex flex-col' onOpenAutoFocus={(e) => e.preventDefault()}>
+        <DialogHeader className='flex flex-row items-center justify-between  mt-4'>
           <DialogTitle>사용자 등록</DialogTitle>
+          <div className='flex gap-1'>
+            <ExportUsersButton />
+            <ImportUsersButton onImportComplete={handleImportComplete} />
+          </div>
         </DialogHeader>
 
-        <div className="flex flex-col gap-2 min-h-0 flex-1 overflow-y-auto p-1">
+        <div className='flex flex-col gap-2 min-h-0 flex-1 overflow-y-auto p-1'>
           {rows.map((row, index) => (
-            <div key={index} className="flex items-center gap-2">
-              <span className="w-6 text-center text-sm text-muted-foreground">{index + 1}</span>
+            <div key={index} className='flex items-center gap-2'>
+              <span className='w-6 text-center text-sm text-muted-foreground'>{index + 1}</span>
               <Input
                 ref={(el) => {
                   inputRefs.current[index] = el;
                 }}
-                placeholder="Jira ID (Account ID)"
+                placeholder='Jira ID (Account ID)'
                 value={row.id}
                 onChange={(e) => handleIdChange(index, e.target.value)}
                 disabled={row.isLoading}
-                className="flex-1"
+                className='flex-1'
               />
               {/* 상태 표시 영역 */}
-              <div className="w-32 h-9 flex items-center">
+              <div className='w-32 h-9 flex items-center'>
                 {row.isLoading ? (
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  <Loader2 className='h-5 w-5 animate-spin text-muted-foreground' />
                 ) : row.isVerified && row.displayName ? (
-                  <span className="text-sm truncate" title={row.displayName}>
+                  <span className='text-sm truncate' title={row.displayName}>
                     {row.displayName}
                   </span>
                 ) : row.hasError ? (
-                  <div className="flex items-center gap-1">
-                    <span className="text-sm text-red-500">조회 실패</span>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleRetry(index)}
-                      className="h-6 w-6 p-0"
-                    >
-                      <RefreshCw className="h-4 w-4" />
+                  <div className='flex items-center gap-1'>
+                    <span className='text-sm text-red-500'>조회 실패</span>
+                    <Button variant='ghost' size='sm' onClick={() => handleRetry(index)} className='h-6 w-6 p-0'>
+                      <RefreshCw className='h-4 w-4' />
                     </Button>
                   </div>
                 ) : row.id.trim() ? (
-                  <span className="text-sm text-muted-foreground">조회 중...</span>
+                  <span className='text-sm text-muted-foreground'>조회 중...</span>
                 ) : (
-                  <span className="text-sm text-muted-foreground">없음</span>
+                  <span className='text-sm text-muted-foreground'>없음</span>
                 )}
               </div>
-              <Button variant="ghost" size="sm" onClick={() => handleRemoveRow(index)} className="px-2">
+              <Button variant='ghost' size='sm' onClick={() => handleRemoveRow(index)} className='px-2'>
                 ✕
               </Button>
             </div>
           ))}
         </div>
 
-        <Button variant="outline" onClick={handleAddRow} className="w-full">
+        <Button variant='outline' onClick={handleAddRow} className='w-full'>
           + 사용자 추가
         </Button>
 
         <DialogFooter>
-          <Button variant="secondary" onClick={() => setOpen(false)}>
+          <Button variant='secondary' onClick={() => setOpen(false)}>
             취소
           </Button>
           <Button onClick={handleSave}>저장</Button>

--- a/src/4_features/user-register-modal/UserRegisterModal.tsx
+++ b/src/4_features/user-register-modal/UserRegisterModal.tsx
@@ -1,5 +1,5 @@
 import { Loader2, RefreshCw } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ExportUsersButton } from '@/4_features/export-users';
 import { ImportUsersButton } from '@/4_features/import-users';
@@ -182,6 +182,19 @@ function UserRegisterModal() {
     setRows(newRows);
   }, []);
 
+  // Import 시 현재 모달의 rows를 JiraUser 형태로 변환
+  const currentUsersForImport = useMemo<JiraUser[]>(
+    () =>
+      rows
+        .filter((row) => row.id.trim() !== '')
+        .map((row) => ({
+          id: row.id.trim(),
+          displayName: row.displayName,
+          isVerified: row.isVerified,
+        })),
+    [rows],
+  );
+
   // 컴포넌트 언마운트 시 타이머 정리
   useEffect(() => {
     return () => {
@@ -198,8 +211,8 @@ function UserRegisterModal() {
         <DialogHeader className='flex flex-row items-center justify-between  mt-4'>
           <DialogTitle>사용자 등록</DialogTitle>
           <div className='flex gap-1'>
-            <ExportUsersButton />
-            <ImportUsersButton onImportComplete={handleImportComplete} />
+            <ExportUsersButton users={currentUsersForImport} />
+            <ImportUsersButton currentUsers={currentUsersForImport} onImportComplete={handleImportComplete} />
           </div>
         </DialogHeader>
 

--- a/src/6_shared/shadcn/index.ts
+++ b/src/6_shared/shadcn/index.ts
@@ -24,3 +24,4 @@ export {
   DropdownMenuSeparator,
 } from './ui/dropdown-menu';
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip';
+export { Progress } from './ui/progress';

--- a/src/6_shared/shadcn/ui/progress.tsx
+++ b/src/6_shared/shadcn/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/6_shared/shadcn/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }


### PR DESCRIPTION
## 배경 (문제 & 원인)

- 사용자 목록을 백업하거나 다른 환경에서 복원할 수 있는 기능 필요
- 다수의 사용자를 한 번에 등록할 수 있는 방법 필요

## 작업 상세 (해결)

### 신규 기능
- **Export**: 현재 등록된 사용자 목록을 JSON 파일로 내보내기
- **Import**: JSON 파일에서 사용자 목록 가져오기
  - 병합 모드: 기존 사용자 유지, 새 사용자만 추가
  - 대체 모드: 기존 사용자 삭제 후 교체
- Import 시 Jira API를 통해 사용자 유효성 검증
- 가져오기 진행률 표시 및 중간 취소 기능

### 버그 수정
- Import/Export가 모달의 로컬 상태만 업데이트하도록 수정 (저장 버튼 클릭 전까지 차트에 반영 안됨)
- 저장 시 사용자 목록이 실제로 변경되었을 때만 차트 재조회 (깜빡임 해결)

### 변경된 파일
- `export-users/` - Export 기능 구현
- `import-users/` - Import 기능 구현
- `UserRegisterModal.tsx` - Export/Import 버튼 추가
- `MainPage.tsx` - 불필요한 재조회 방지 로직

## 테스트 방법 (기대 결과)

1. 
2. 