### PR TITLE
feat: 타임라인 새로고침 및 토큰 갱신 기능 추가

### DIFF
--- a/src/2_pages/main/MainPage.tsx
+++ b/src/2_pages/main/MainPage.tsx
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Timeline, {
   DateHeader,
   SidebarHeader,
@@ -9,7 +9,9 @@ import Timeline, {
 } from 'react-calendar-timeline';
 
 import { Header } from '@/3_widgets/header';
+import { RefreshVisibleRangeButton } from '@/4_features/refresh-visible-range';
 import { UserRegisterModal } from '@/4_features/user-register-modal';
+import { useRefreshToken } from '@/5_entities/auth';
 import { getIssues, useIssueStore } from '@/5_entities/jira';
 import { useClientStore } from '@/5_entities/jira/jiraClientStore';
 import { useUserStore } from '@/5_entities/user';
@@ -42,16 +44,26 @@ function debounce<T extends (...args: Parameters<T>) => void>(fn: T, delay: numb
 function MainPage() {
   const { client } = useClientStore();
   const { users } = useUserStore();
+  const { refresh: refreshToken } = useRefreshToken();
   const {
     issues,
     fetchedRanges,
     addIssues,
     addFetchedRange,
+    removeFetchedRange,
     incrementLoading,
     decrementLoading,
     setError,
     clear,
+    isLoading,
   } = useIssueStore();
+
+  // 현재 보이는 구간 저장 (새로고침 시 사용)
+  // Timeline의 defaultTimeStart/End와 동일한 초기값 설정
+  const [visibleRange, setVisibleRange] = useState<DateRange>(() => ({
+    start: moment().add(-1, 'month').format('YYYY-MM-DD'),
+    end: moment().add(1, 'month').format('YYYY-MM-DD'),
+  }));
 
   // 조회 중인 구간을 추적 (중복 요청 방지)
   const fetchingRanges = useRef<Set<string>>(new Set());
@@ -81,6 +93,9 @@ function MainPage() {
         const newIssues = await getIssues(client, range);
         addIssues(newIssues);
         addFetchedRange(range);
+
+        // API 호출 성공 시 토큰 갱신 (세션 연장)
+        refreshToken();
       } catch (err) {
         const message = err instanceof Error ? err.message : '이슈 조회 중 오류가 발생했습니다.';
         setError(message);
@@ -90,7 +105,7 @@ function MainPage() {
         decrementLoading();
       }
     },
-    [addIssues, addFetchedRange, incrementLoading, decrementLoading, setError],
+    [addIssues, addFetchedRange, incrementLoading, decrementLoading, setError, refreshToken],
   );
 
   // 필요한 구간들 조회 (ref에서 최신 상태 참조)
@@ -179,9 +194,29 @@ function MainPage() {
 
       // 스크롤 캔버스는 즉시 업데이트
       updateScrollCanvas(visibleTimeStart, visibleTimeEnd);
+
+      // 현재 보이는 범위 저장 (새로고침 시 사용)
+      setVisibleRange({
+        start: moment(visibleTimeStart).format('YYYY-MM-DD'),
+        end: moment(visibleTimeEnd).format('YYYY-MM-DD'),
+      });
     },
     [],
   );
+
+  // 현재 구간 새로고침 핸들러
+  const handleRefreshVisibleRange = useCallback(() => {
+    // fetchedRanges에서 현재 범위 제거
+    removeFetchedRange(visibleRange);
+
+    // stateRef 업데이트 (fetchRangesIfNeeded가 참조하는 값)
+    stateRef.current.fetchedRanges = useIssueStore.getState().fetchedRanges;
+
+    // 재조회 트리거 (버퍼 포함)
+    const start = moment(visibleRange.start).valueOf();
+    const end = moment(visibleRange.end).valueOf();
+    fetchRangesIfNeeded(start, end);
+  }, [visibleRange, removeFetchedRange, fetchRangesIfNeeded]);
 
   // store의 issues를 배열로 변환
   const issueList = useMemo(() => Object.values(issues), [issues]);
@@ -334,6 +369,11 @@ function MainPage() {
           />
         </TimelineHeaders>
       </Timeline>
+
+      <RefreshVisibleRangeButton
+        onRefresh={handleRefreshVisibleRange}
+        isLoading={isLoading()}
+      />
     </div>
   );
 }

--- a/src/4_features/refresh-visible-range/RefreshVisibleRangeButton.tsx
+++ b/src/4_features/refresh-visible-range/RefreshVisibleRangeButton.tsx
@@ -12,7 +12,7 @@ type RefreshVisibleRangeButtonProps = {
 function RefreshVisibleRangeButton({ onRefresh, isLoading, disabled = false }: RefreshVisibleRangeButtonProps) {
   return (
     <TooltipProvider>
-      <Tooltip>
+      <Tooltip delayDuration={50}>
         <TooltipTrigger asChild>
           <Button
             className='fixed bottom-6 right-6 rounded-full shadow-lg z-10'

--- a/src/4_features/refresh-visible-range/RefreshVisibleRangeButton.tsx
+++ b/src/4_features/refresh-visible-range/RefreshVisibleRangeButton.tsx
@@ -1,0 +1,34 @@
+import { Loader2, RefreshCw } from 'lucide-react';
+
+import { Button } from '@/6_shared/shadcn/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/6_shared/shadcn/ui/tooltip';
+
+type RefreshVisibleRangeButtonProps = {
+  onRefresh: () => void;
+  isLoading: boolean;
+  disabled?: boolean;
+};
+
+function RefreshVisibleRangeButton({ onRefresh, isLoading, disabled = false }: RefreshVisibleRangeButtonProps) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            className='fixed bottom-6 right-6 rounded-full shadow-lg z-10'
+            size='icon'
+            onClick={onRefresh}
+            disabled={isLoading || disabled}
+          >
+            {isLoading ? <Loader2 className='h-5 w-5 animate-spin' /> : <RefreshCw className='h-5 w-5' />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side='left'>
+          <p>현재 구간 새로고침</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export default RefreshVisibleRangeButton;

--- a/src/4_features/refresh-visible-range/index.ts
+++ b/src/4_features/refresh-visible-range/index.ts
@@ -1,0 +1,1 @@
+export { default as RefreshVisibleRangeButton } from './RefreshVisibleRangeButton';

--- a/src/4_features/token-countdown/TokenCountdown.tsx
+++ b/src/4_features/token-countdown/TokenCountdown.tsx
@@ -1,7 +1,8 @@
+import { Loader2, RefreshCw } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
-import { useAuthStore } from '@/5_entities/auth';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/6_shared/shadcn';
+import { useAuthStore, useRefreshToken } from '@/5_entities/auth';
+import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/6_shared/shadcn';
 
 function formatTime(ms: number): string {
   if (ms <= 0) return '00:00';
@@ -15,6 +16,7 @@ function formatTime(ms: number): string {
 
 function TokenCountdown({ onExpired }: { onExpired: () => void }) {
   const { expiresAt } = useAuthStore();
+  const { refresh, isRefreshing } = useRefreshToken();
   const [remainingTime, setRemainingTime] = useState<number>(0);
   const intervalRef = useRef<number | null>(null);
 
@@ -40,6 +42,7 @@ function TokenCountdown({ onExpired }: { onExpired: () => void }) {
     return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
     };
   }, [expiresAt, onExpired]);
@@ -49,22 +52,49 @@ function TokenCountdown({ onExpired }: { onExpired: () => void }) {
   const isWarning = remainingTime <= 5 * 60 * 1000; // 5분 이하
   const isExpired = remainingTime <= 0;
 
+  const handleRefresh = async () => {
+    await refresh();
+  };
+
   return (
     <TooltipProvider delayDuration={50}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className={`text-sm font-mono cursor-help ${
-              isExpired ? 'text-red-600' : isWarning ? 'text-orange-500' : 'text-gray-500'
-            }`}
-          >
-            {formatTime(remainingTime)}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>세션 만료까지 남은 시간</p>
-        </TooltipContent>
-      </Tooltip>
+      <div className="flex items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className={`text-sm font-mono cursor-help ${
+                isExpired ? 'text-red-600' : isWarning ? 'text-orange-500' : 'text-gray-500'
+              }`}
+            >
+              {formatTime(remainingTime)}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>세션 만료까지 남은 시간</p>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+            >
+              {isRefreshing ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3 w-3" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>토큰 갱신</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
     </TooltipProvider>
   );
 }

--- a/src/5_entities/auth/index.ts
+++ b/src/5_entities/auth/index.ts
@@ -2,3 +2,4 @@ export { getAuthorizationUrl, parseOauthCodeBySelf, exchangeAuthCodeForAccessTok
 export type { JiraCurrentUser } from './oauth';
 export { useAuthStore } from './authStore';
 export { useAuth } from './useAuth';
+export { useRefreshToken } from './useRefreshToken';

--- a/src/5_entities/auth/useRefreshToken.ts
+++ b/src/5_entities/auth/useRefreshToken.ts
@@ -1,0 +1,60 @@
+import { useCallback, useState } from 'react';
+
+import { useClientStore } from '@/5_entities/jira/jiraClientStore';
+
+import { useAuthStore } from './authStore';
+import { refreshAccessToken } from './oauth';
+
+type RefreshResult = {
+  success: boolean;
+  error?: string;
+};
+
+export function useRefreshToken() {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const { refreshToken, cloudId, setAccessToken, setRefreshToken, setExpiresAt } = useAuthStore();
+  const { initClient } = useClientStore();
+
+  const refresh = useCallback(async (): Promise<RefreshResult> => {
+    if (!refreshToken) {
+      return { success: false, error: '갱신 토큰이 없습니다.' };
+    }
+
+    if (isRefreshing) {
+      return { success: false, error: '이미 갱신 중입니다.' };
+    }
+
+    setIsRefreshing(true);
+
+    try {
+      const {
+        access_token: newAccessToken,
+        refresh_token: newRefreshToken,
+        expires_in: expiresIn,
+      } = await refreshAccessToken(refreshToken);
+
+      const expiresAt = Date.now() + expiresIn * 1000;
+
+      setAccessToken(newAccessToken);
+      setRefreshToken(newRefreshToken);
+      setExpiresAt(expiresAt);
+
+      if (cloudId) {
+        initClient(newAccessToken, cloudId);
+      }
+
+      return { success: true };
+    } catch (err) {
+      console.error('Token refresh failed:', err);
+      return { success: false, error: '토큰 갱신에 실패했습니다.' };
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [refreshToken, cloudId, isRefreshing, setAccessToken, setRefreshToken, setExpiresAt, initClient]);
+
+  return {
+    refresh,
+    isRefreshing,
+  };
+}

--- a/src/5_entities/jira/issueStore.ts
+++ b/src/5_entities/jira/issueStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import { type DateRange, mergeRanges } from '@/6_shared/utils';
+import { type DateRange, mergeRanges, subtractRange } from '@/6_shared/utils';
 
 import type { Issue } from './jira';
 
@@ -17,6 +17,7 @@ interface IssueStore {
   // 액션
   addIssues: (newIssues: Issue[]) => void;
   addFetchedRange: (range: DateRange) => void;
+  removeFetchedRange: (range: DateRange) => void;
   incrementLoading: () => void;
   decrementLoading: () => void;
   setError: (error: string | null) => void;
@@ -45,6 +46,11 @@ export const useIssueStore = create<IssueStore>((set, get) => ({
       const merged = mergeRanges([...state.fetchedRanges, range]);
       return { fetchedRanges: merged };
     }),
+
+  removeFetchedRange: (range) =>
+    set((state) => ({
+      fetchedRanges: subtractRange(state.fetchedRanges, range),
+    })),
 
   incrementLoading: () =>
     set((state) => ({

--- a/src/6_shared/utils/__tests__/dateRangeUtils.test.ts
+++ b/src/6_shared/utils/__tests__/dateRangeUtils.test.ts
@@ -5,6 +5,7 @@ import {
   getNonOverlappingRanges,
   mergeRanges,
   normalizeDateRange,
+  subtractRange,
   type DateRange,
 } from '../dateRangeUtils';
 
@@ -218,6 +219,107 @@ describe('mergeRanges', () => {
       { start: '2024-01-10', end: '2024-01-20' },
     ]);
     expect(result).toEqual([{ start: '2024-01-01', end: '2024-01-31' }]);
+  });
+});
+
+describe('subtractRange', () => {
+  it('빈 배열에서 제거 시 빈 배열 반환', () => {
+    const result = subtractRange([], { start: '2024-01-01', end: '2024-01-31' });
+    expect(result).toEqual([]);
+  });
+
+  it('겹치지 않는 범위는 그대로 유지', () => {
+    const result = subtractRange(
+      [{ start: '2024-01-01', end: '2024-01-31' }],
+      { start: '2024-03-01', end: '2024-03-31' }
+    );
+    expect(result).toEqual([{ start: '2024-01-01', end: '2024-01-31' }]);
+  });
+
+  it('완전히 포함되는 범위 제거', () => {
+    const result = subtractRange(
+      [{ start: '2024-01-10', end: '2024-01-20' }],
+      { start: '2024-01-01', end: '2024-01-31' }
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('동일한 범위 제거', () => {
+    const result = subtractRange(
+      [{ start: '2024-01-01', end: '2024-01-31' }],
+      { start: '2024-01-01', end: '2024-01-31' }
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('범위 중간 부분 제거 (분할)', () => {
+    const result = subtractRange(
+      [{ start: '2024-01-01', end: '2024-01-31' }],
+      { start: '2024-01-10', end: '2024-01-20' }
+    );
+    expect(result).toEqual([
+      { start: '2024-01-01', end: '2024-01-09' },
+      { start: '2024-01-21', end: '2024-01-31' },
+    ]);
+  });
+
+  it('범위 시작 부분 제거', () => {
+    const result = subtractRange(
+      [{ start: '2024-01-01', end: '2024-01-31' }],
+      { start: '2024-01-01', end: '2024-01-15' }
+    );
+    expect(result).toEqual([{ start: '2024-01-16', end: '2024-01-31' }]);
+  });
+
+  it('범위 끝 부분 제거', () => {
+    const result = subtractRange(
+      [{ start: '2024-01-01', end: '2024-01-31' }],
+      { start: '2024-01-20', end: '2024-01-31' }
+    );
+    expect(result).toEqual([{ start: '2024-01-01', end: '2024-01-19' }]);
+  });
+
+  it('여러 범위에서 일부만 제거', () => {
+    const result = subtractRange(
+      [
+        { start: '2024-01-01', end: '2024-01-15' },
+        { start: '2024-02-01', end: '2024-02-15' },
+      ],
+      { start: '2024-01-10', end: '2024-01-20' }
+    );
+    expect(result).toEqual([
+      { start: '2024-01-01', end: '2024-01-09' },
+      { start: '2024-02-01', end: '2024-02-15' },
+    ]);
+  });
+
+  it('여러 범위 중 하나 완전 제거', () => {
+    const result = subtractRange(
+      [
+        { start: '2024-01-01', end: '2024-01-15' },
+        { start: '2024-02-01', end: '2024-02-15' },
+        { start: '2024-03-01', end: '2024-03-15' },
+      ],
+      { start: '2024-02-01', end: '2024-02-15' }
+    );
+    expect(result).toEqual([
+      { start: '2024-01-01', end: '2024-01-15' },
+      { start: '2024-03-01', end: '2024-03-15' },
+    ]);
+  });
+
+  it('제거 범위가 여러 범위에 걸쳐있는 경우', () => {
+    const result = subtractRange(
+      [
+        { start: '2024-01-01', end: '2024-01-31' },
+        { start: '2024-02-01', end: '2024-02-28' },
+      ],
+      { start: '2024-01-20', end: '2024-02-10' }
+    );
+    expect(result).toEqual([
+      { start: '2024-01-01', end: '2024-01-19' },
+      { start: '2024-02-11', end: '2024-02-28' },
+    ]);
   });
 });
 

--- a/src/6_shared/utils/dateRangeUtils.ts
+++ b/src/6_shared/utils/dateRangeUtils.ts
@@ -125,3 +125,65 @@ export function mergeRanges(ranges: DateRange[]): DateRange[] {
 
   return merged;
 }
+
+/**
+ * 범위 배열에서 특정 범위를 제거
+ * @param ranges 기존 범위 배열
+ * @param rangeToRemove 제거할 범위
+ * @returns 제거 후 남은 범위 배열
+ */
+export function subtractRange(ranges: DateRange[], rangeToRemove: DateRange): DateRange[] {
+  if (ranges.length === 0) return [];
+
+  const result: DateRange[] = [];
+  const removeStart = moment(rangeToRemove.start);
+  const removeEnd = moment(rangeToRemove.end);
+
+  for (const range of ranges) {
+    const rangeStart = moment(range.start);
+    const rangeEnd = moment(range.end);
+
+    // 제거 범위와 전혀 겹치지 않는 경우 그대로 유지
+    if (rangeEnd.isBefore(removeStart) || rangeStart.isAfter(removeEnd)) {
+      result.push({ ...range });
+      continue;
+    }
+
+    // 제거 범위가 현재 범위를 완전히 포함하는 경우 제거
+    if (removeStart.isSameOrBefore(rangeStart) && removeEnd.isSameOrAfter(rangeEnd)) {
+      continue;
+    }
+
+    // 제거 범위가 현재 범위 중간에 있는 경우 분할
+    if (removeStart.isAfter(rangeStart) && removeEnd.isBefore(rangeEnd)) {
+      result.push({
+        start: range.start,
+        end: removeStart.clone().subtract(1, 'day').format('YYYY-MM-DD'),
+      });
+      result.push({
+        start: removeEnd.clone().add(1, 'day').format('YYYY-MM-DD'),
+        end: range.end,
+      });
+      continue;
+    }
+
+    // 제거 범위가 현재 범위 시작 부분과 겹치는 경우
+    if (removeStart.isSameOrBefore(rangeStart) && removeEnd.isBefore(rangeEnd)) {
+      result.push({
+        start: removeEnd.clone().add(1, 'day').format('YYYY-MM-DD'),
+        end: range.end,
+      });
+      continue;
+    }
+
+    // 제거 범위가 현재 범위 끝 부분과 겹치는 경우
+    if (removeStart.isAfter(rangeStart) && removeEnd.isSameOrAfter(rangeEnd)) {
+      result.push({
+        start: range.start,
+        end: removeStart.clone().subtract(1, 'day').format('YYYY-MM-DD'),
+      });
+    }
+  }
+
+  return result;
+}

--- a/src/6_shared/utils/index.ts
+++ b/src/6_shared/utils/index.ts
@@ -3,4 +3,5 @@ export {
   normalizeDateRange,
   getNonOverlappingRanges,
   mergeRanges,
+  subtractRange,
 } from './dateRangeUtils';


### PR DESCRIPTION
## 배경 (문제 & 원인)

- 타임라인에서 이미 조회된 구간은 재조회가 불가능했음
- 토큰이 만료되기 전에 수동으로 갱신할 방법이 없었음
- 사용자가 타임라인을 사용하는 동안 세션이 만료될 수 있었음

## 작업 상세 (해결)

### 1. 타임라인 현재 구간 새로고침
- 우측 하단 Floating 버튼 추가 (RefreshVisibleRangeButton)
- subtractRange 유틸 함수로 fetchedRanges에서 현재 범위 제거
- removeFetchedRange 액션 추가 (issueStore)

### 2. 토큰 갱신 기능
- 만료 시간 옆에 수동 갱신 버튼 추가 (TokenCountdown)
- useRefreshToken 훅으로 토큰 갱신 로직 분리
- 지라 API 호출 성공 시 토큰 자동 갱신 (세션 연장)

### 변경 파일
- `MainPage.tsx` - 새로고침 기능 통합, 토큰 자동 갱신
- `RefreshVisibleRangeButton.tsx` - 신규 컴포넌트
- `TokenCountdown.tsx` - 갱신 버튼 추가
- `useRefreshToken.ts` - 신규 훅
- `issueStore.ts` - removeFetchedRange 액션 추가
- `dateRangeUtils.ts` - subtractRange 함수 추가

## 테스트 방법 (기대 결과)

1. 
2. 