### PR TITLE
feat: 이슈 상태별 색상 표시 및 툴팁 기능 추가

### DIFF
--- a/src/2_pages/main/MainPage.tsx
+++ b/src/2_pages/main/MainPage.tsx
@@ -12,9 +12,10 @@ import { Header } from '@/3_widgets/header';
 import { RefreshVisibleRangeButton } from '@/4_features/refresh-visible-range';
 import { UserRegisterModal } from '@/4_features/user-register-modal';
 import { useRefreshToken } from '@/5_entities/auth';
-import { getIssues, useIssueStore } from '@/5_entities/jira';
+import { getIssues, getStatusColors, useIssueStore } from '@/5_entities/jira';
 import { useClientStore } from '@/5_entities/jira/jiraClientStore';
 import { useUserStore } from '@/5_entities/user';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/6_shared/shadcn';
 import { type DateRange, getNonOverlappingRanges, normalizeDateRange } from '@/6_shared/utils';
 
 /**
@@ -242,6 +243,8 @@ function MainPage() {
         title: issue.summary,
         start_time: moment(issue.startTime),
         end_time: moment(issue.endTime).add(1, 'day'),
+        statusCategory: issue.statusCategory,
+        statusName: issue.status,
       }));
   }, [issueList]);
 
@@ -276,46 +279,62 @@ function MainPage() {
         lineHeight={60}
         itemRenderer={({ item, itemContext, getItemProps, getResizeProps }) => {
           const { left: leftResizeProps, right: rightResizeProps } = getResizeProps();
+          const colors = getStatusColors(item.statusCategory?.key);
           return (
-            <div
-              {...getItemProps({
-                style: { padding: '0 3px', background: 'none', border: 'none' },
-              })}
-              onClick={() => {
-                window.open(`https://whatap-labs.atlassian.net/browse/${item.id}`, '_blank');
-              }}
-            >
-              <div
-                style={{
-                  backgroundColor: '#dddddd88',
-                  color: '#666',
-                  borderColor: '#666',
-                  borderStyle: 'solid',
-                  borderWidth: itemContext.selected ? 3 : 1,
-                  borderRadius: 4,
-                  boxSizing: 'border-box',
-                  height: itemContext.dimensions.height,
-                }}
-              >
-                {itemContext.useResizeHandle ? <div {...leftResizeProps} /> : null}
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    {...getItemProps({
+                      style: { padding: '0 3px', background: 'none', border: 'none' },
+                    })}
+                    onClick={() => {
+                      window.open(`https://whatap-labs.atlassian.net/browse/${item.id}`, '_blank');
+                    }}
+                  >
+                    <div
+                      style={{
+                        backgroundColor: colors.backgroundColor,
+                        color: colors.textColor,
+                        borderColor: colors.borderColor,
+                        borderStyle: 'solid',
+                        borderWidth: itemContext.selected ? 3 : 1,
+                        borderRadius: 4,
+                        boxSizing: 'border-box',
+                        height: itemContext.dimensions.height,
+                        cursor: 'pointer',
+                      }}
+                    >
+                      {itemContext.useResizeHandle ? <div {...leftResizeProps} /> : null}
 
-                <div
-                  style={{
-                    overflow: 'hidden',
-                    paddingLeft: 3,
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    display: 'flex',
-                    alignItems: 'center',
-                    height: '100%',
-                  }}
-                >
-                  {itemContext.title}
-                </div>
+                      <div
+                        style={{
+                          overflow: 'hidden',
+                          paddingLeft: 3,
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          display: 'flex',
+                          alignItems: 'center',
+                          height: '100%',
+                        }}
+                      >
+                        {itemContext.title}
+                      </div>
 
-                {itemContext.useResizeHandle ? <div {...rightResizeProps} /> : null}
-              </div>
-            </div>
+                      {itemContext.useResizeHandle ? <div {...rightResizeProps} /> : null}
+                    </div>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-sm">
+                    <div className="font-medium">{itemContext.title}</div>
+                    {item.statusName && (
+                      <div style={{ color: colors.textColor }}>{item.statusName}</div>
+                    )}
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           );
         }}
         sidebarWidth={150}

--- a/src/5_entities/jira/index.ts
+++ b/src/5_entities/jira/index.ts
@@ -1,3 +1,11 @@
-export { getIssues, getJiraUser, type Issue, type JiraUserInfo } from './jira';
+export {
+  getIssues,
+  getJiraUser,
+  type Issue,
+  type JiraUserInfo,
+  type StatusCategory,
+  type StatusCategoryKey,
+} from './jira';
 export { useClientStore } from './jiraClientStore';
 export { useIssueStore } from './issueStore';
+export { getStatusColors, type StatusColors } from './util/statusColor';

--- a/src/5_entities/jira/jira.ts
+++ b/src/5_entities/jira/jira.ts
@@ -2,6 +2,15 @@ import { Version3Client } from 'jira.js';
 
 import type { DateRange } from '@/6_shared/utils';
 
+// StatusCategory 타입 정의
+export type StatusCategoryKey = 'new' | 'indeterminate' | 'done';
+
+export interface StatusCategory {
+  key: StatusCategoryKey;
+  colorName: string;
+  name: string;
+}
+
 // Issue 타입 정의
 export interface Issue {
   key: string;
@@ -14,6 +23,7 @@ export interface Issue {
   endTime: string; // YYYY-MM-DD
   issueType?: string;
   status?: string;
+  statusCategory?: StatusCategory;
   link: string;
 }
 
@@ -25,7 +35,14 @@ interface JiraIssueResponse {
     creator?: { displayName?: string } | null;
     summary?: string | null;
     issuetype?: { name?: string } | null;
-    status?: { name?: string } | null;
+    status?: {
+      name?: string;
+      statusCategory?: {
+        key?: string;
+        colorName?: string;
+        name?: string;
+      };
+    } | null;
     customfield_10156?: string | null; // 시작일
     customfield_10157?: string | null; // 종료일
   };
@@ -76,6 +93,7 @@ export async function getIssues(client: Version3Client, dateRange: DateRange): P
   const allIssues: Issue[] = [];
   results.forEach(({ userId, issues }) => {
     issues.forEach((issue) => {
+      const statusCat = issue.fields.status?.statusCategory;
       allIssues.push({
         key: issue.key,
         userId,
@@ -87,6 +105,13 @@ export async function getIssues(client: Version3Client, dateRange: DateRange): P
         endTime: issue.fields.customfield_10157 ?? '',
         issueType: issue.fields.issuetype?.name,
         status: issue.fields.status?.name,
+        statusCategory: statusCat?.key
+          ? {
+              key: statusCat.key as StatusCategoryKey,
+              colorName: statusCat.colorName ?? '',
+              name: statusCat.name ?? '',
+            }
+          : undefined,
         link: `https://whatap-labs.atlassian.net/browse/${issue.key}`,
       });
     });

--- a/src/5_entities/jira/util/statusColor.ts
+++ b/src/5_entities/jira/util/statusColor.ts
@@ -1,0 +1,36 @@
+import type { StatusCategoryKey } from '../jira';
+
+export interface StatusColors {
+  backgroundColor: string;
+  textColor: string;
+  borderColor: string;
+}
+
+const STATUS_COLOR_MAP: Record<StatusCategoryKey, StatusColors> = {
+  new: {
+    backgroundColor: '#dfe1e6',
+    textColor: '#42526e',
+    borderColor: '#b3bac5',
+  },
+  indeterminate: {
+    backgroundColor: '#deebff',
+    textColor: '#0747a6',
+    borderColor: '#4c9aff',
+  },
+  done: {
+    backgroundColor: '#e3fcef',
+    textColor: '#006644',
+    borderColor: '#57d9a3',
+  },
+};
+
+const DEFAULT_COLORS: StatusColors = {
+  backgroundColor: '#dddddd88',
+  textColor: '#666',
+  borderColor: '#666',
+};
+
+export function getStatusColors(key?: StatusCategoryKey): StatusColors {
+  if (!key) return DEFAULT_COLORS;
+  return STATUS_COLOR_MAP[key] ?? DEFAULT_COLORS;
+}

--- a/src/5_entities/jira/util/test/statusColor.test.ts
+++ b/src/5_entities/jira/util/test/statusColor.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+
+import { getStatusColors } from '../statusColor';
+
+describe('getStatusColors', () => {
+  it('returns correct colors for "new" status', () => {
+    const colors = getStatusColors('new');
+    expect(colors.backgroundColor).toBe('#dfe1e6');
+    expect(colors.textColor).toBe('#42526e');
+    expect(colors.borderColor).toBe('#b3bac5');
+  });
+
+  it('returns correct colors for "indeterminate" status', () => {
+    const colors = getStatusColors('indeterminate');
+    expect(colors.backgroundColor).toBe('#deebff');
+    expect(colors.textColor).toBe('#0747a6');
+    expect(colors.borderColor).toBe('#4c9aff');
+  });
+
+  it('returns correct colors for "done" status', () => {
+    const colors = getStatusColors('done');
+    expect(colors.backgroundColor).toBe('#e3fcef');
+    expect(colors.textColor).toBe('#006644');
+    expect(colors.borderColor).toBe('#57d9a3');
+  });
+
+  it('returns default colors for undefined', () => {
+    const colors = getStatusColors(undefined);
+    expect(colors.backgroundColor).toBe('#dddddd88');
+    expect(colors.textColor).toBe('#666');
+    expect(colors.borderColor).toBe('#666');
+  });
+});


### PR DESCRIPTION
## 배경 (문제 & 원인)

- 타임라인에서 이슈의 상태(To Do, In Progress, Done)를 시각적으로 구분하기 어려움
- 차트 축소 시 이슈 제목이 잘려서 보이지 않음

## 작업 상세 (해결)

- StatusCategory 타입 정의 (new, indeterminate, done)
- 상태별 색상 매핑 유틸리티 추가 (getStatusColors)
  - To Do: 회색 (#dfe1e6)
  - In Progress: 파란색 (#deebff)
  - Done: 초록색 (#e3fcef)
- 타임라인 이슈 바에 상태별 배경색 적용
- 마우스 호버 시 shadcn Tooltip으로 전체 제목과 상태 표시

## 테스트 방법 (기대 결과)

1. 타임라인에서 이슈 확인 - 상태별로 다른 배경색 적용 확인
2. 이슈 바에 마우스 호버 - 툴팁으로 전체 제목과 상태 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/code)